### PR TITLE
Clean up HTML code and complete implementation for limit

### DIFF
--- a/client/src/app/todos/todos-card.component.html
+++ b/client/src/app/todos/todos-card.component.html
@@ -2,7 +2,11 @@
   <mat-card-header>
     <mat-card-title class="todos-card-name">{{ this.todos.owner }}</mat-card-title>
     <mat-card-subtitle>Category: <span class="todos-card-category">{{ todos.category }}</span></mat-card-subtitle>
-    <mat-card-subtitle>Status: <span class="todos-card-status">{{ todos.status }}</span></mat-card-subtitle>
+    <mat-card-subtitle>Status: <span class="todos-card-status" *ngIf='todos.status; else elseBlock'>Complete</span>
+    </mat-card-subtitle>
+    <ng-template #elseBlock>
+      <span class="todos-card-status">Incomplete</span>
+    </ng-template>
   </mat-card-header>
   <mat-card-content *ngIf="!this.simple">
     <p class="todos-card-body">{{ this.todos.body }}</p>

--- a/client/src/app/todos/todos-list.component.html
+++ b/client/src/app/todos/todos-list.component.html
@@ -32,13 +32,21 @@
 
             <mat-form-field class="input-field">
               <mat-label>Status</mat-label>
-              <mat-select (selectionChange)="getTodosFromServer()" [(ngModel)]="todosStatus" data-test="userRoleSelect">
+              <mat-select (selectionChange)="getTodosFromServer()" [(ngModel)]="todosStatus" data-test="todosStatusSelect">
                 <mat-option>--</mat-option>
                 <mat-option value="complete">Complete</mat-option>
                 <mat-option value="incomplete">Incomplete</mat-option>
               </mat-select>
               <mat-hint>Filtered on server</mat-hint>
             </mat-form-field>
+
+            <mat-form-field class="input-field">
+              <mat-label>Limit</mat-label>
+              <input matInput id="todos-limit" type="number" placeholder="Filter by limit"
+              min="0" max="300" [(ngModel)]="limit" (input)="updateFilter()">
+              <mat-hint>Filtered on client</mat-hint>
+            </mat-form-field>
+
           </div>
 
         </mat-card-content>
@@ -52,9 +60,16 @@
       <mat-nav-list class="todos-nav-list">
         <h3 mat-subheader>Todos</h3>
         <a mat-list-item *ngFor="let todos of this.filteredTodos" [routerLink]="['/todos', todos._id]" class="todos-list-item">
-          <h3 matLine class="todos-list-owner"> {{todos.owner}} </h3>
-          <p matLine class="todos-list-category"> {{todos.category}} </p>
-          <p matLine class="todos-list-status">{{todos.status}}</p>
+          <div fxLayout="row" fxLayoutAlign="center">
+            <p matLine class="todos-list-status" *ngIf='todos.status; else elseBlock'>
+              <mat-icon matListIcon>check_box</mat-icon></p>
+              <ng-template #elseBlock>
+            <p matLine class="todos-list-status">
+              <mat-icon matListIcon>check_box_outline_blank</mat-icon></p>
+            </ng-template>
+          </div>
+            <h3 matLine class="todos-list-owner"> {{todos.owner}} </h3>
+            <p matLine class="todos-list-category"> {{todos.category}} </p>
         </a>
       </mat-nav-list>
     </mat-card-content>
@@ -67,10 +82,10 @@
 <ng-template #todosError>
   <div fxFlex fxFlex.gt-sm="80" fxFlexOffset.gt-sm="10" class="todos-error">
     <mat-error>
-      There was a problem loading the todos. Possibly the server is down or perhaps there are network issues.
+      If this isn't loading, then the world is burning.
     </mat-error>
     <mat-error>
-      Try unplugging it and plug it back in again.
+      Try unplugging it, wait ten seconds, and plug it back in again.
     </mat-error>
   </div>
 </ng-template>

--- a/client/src/app/todos/todos-list.component.ts
+++ b/client/src/app/todos/todos-list.component.ts
@@ -18,14 +18,13 @@ export class TodosListComponent implements OnInit {
   public todosStatus: TodosStatus;
   public todosBody: string;
   public todosCategory: string;
-  public limit: string;
+  public limit: number;
 
   constructor(private todosService: TodosService, private snackBar: MatSnackBar) { }
 
   getTodosFromServer() {
     this.todosService.getTodos({
       status: this.todosStatus,
-      limit: this.limit
     }).subscribe(returnedTodos => {
       this.serverFilteredTodos = returnedTodos;
       this.updateFilter();
@@ -42,7 +41,7 @@ export class TodosListComponent implements OnInit {
   */
   public updateFilter(){
     this.filteredTodos = this.todosService.filterTodos(
-      this.serverFilteredTodos, { category: this.todosCategory, owner: this.todosOwner, body: this.todosBody });
+      this.serverFilteredTodos, { category: this.todosCategory, owner: this.todosOwner, body: this.todosBody, limit: this.limit });
   }
 
   /**

--- a/client/src/app/todos/todos.service.spec.ts
+++ b/client/src/app/todos/todos.service.spec.ts
@@ -3,7 +3,6 @@ import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { Todos } from './todos';
 import { TodosService } from './todos.service';
-import { getMatTooltipInvalidPositionError } from '@angular/material/tooltip';
 
 describe('TodosService', () => {
 
@@ -83,25 +82,6 @@ describe('TodosService', () => {
 
         req.flush(testTodos);
       });
-
-      it('correctly calls api/user with multiple filter parameters', () => {
-
-        todosService.getTodos({ status: 'complete', limit: '1' }).subscribe(
-          todos => expect(todos).toBe(testTodos)
-        );
-
-        const req = httpTestingController.expectOne(
-          (request) => request.url.startsWith(todosService.todosUrl)
-          && request.params.has('status') && request.params.has('limit')
-        );
-
-        expect(req.request.method).toEqual('GET');
-
-        expect(req.request.params.get('status')).toEqual('complete');
-        expect(req.request.params.get('limit')).toEqual('1');
-
-        req.flush(testTodos);
-      });
     });
   });
 
@@ -174,9 +154,17 @@ describe('TodosService', () => {
     it('returns 0 todos when no todos contain the multiple filters given', () => {
       const todoOwner = 'Fry';
       const todoCategory = 'study';
-      const filteredTodos = todosService.filterTodos(testTodos, { owner: todoOwner, category: todoCategory});
+      const filteredTodos = todosService.filterTodos(testTodos, { owner: todoOwner, category: todoCategory });
 
       expect(filteredTodos.length).toBe(0);
+    });
+
+    it('correctly limits a search based on the limit number given', () => {
+      const todoOwner = 'Fry';
+      const limitNumber = 1;
+      const filteredTodos = todosService.filterTodos(testTodos, { owner: todoOwner, limit: limitNumber });
+
+      expect(filteredTodos.length).toBe(1);
     });
   });
 });

--- a/client/src/app/todos/todos.service.ts
+++ b/client/src/app/todos/todos.service.ts
@@ -12,12 +12,9 @@ export class TodosService {
 
   constructor(private httpClient: HttpClient) { }
 
-  getTodos(filters?: { status?: TodosStatus; limit?: string }): Observable<Todos[]> {
+  getTodos(filters?: { status?: TodosStatus }): Observable<Todos[]> {
     let httpParams: HttpParams = new HttpParams();
     if(filters) {
-      if(filters.limit) {
-        httpParams = httpParams.set('limit', filters.limit);
-      }
       if(filters.status) {
         httpParams = httpParams.set('status', filters.status);
       }
@@ -31,7 +28,7 @@ export class TodosService {
     return this.httpClient.get<Todos>(this.todosUrl + '/' + id);
   }
 
-  filterTodos(todos: Todos[], filters: { category?: string; owner?: string; body?: string }): Todos[] {
+  filterTodos(todos: Todos[], filters: { category?: string; owner?: string; body?: string; limit?: number}): Todos[] {
 
     let filteredTodos = todos;
 
@@ -49,6 +46,9 @@ export class TodosService {
       filters.body = filters.body.toLowerCase();
 
       filteredTodos = filteredTodos.filter(todo => todo.body.toLowerCase().indexOf(filters.body) !== -1);
+    }
+    if(filters.limit) {
+      filteredTodos = filteredTodos.slice(0,filters.limit);
     }
     return filteredTodos;
   }


### PR DESCRIPTION
Cleaned up the HTML code and implemented a text box where the user can limit the number of todos that appear. The "limit" filter is now done on the client-side to prevent bugs with limiting the wrong way (it would limit before adding other filters and therefore wouldn't give all available options). Modified testing in todos.service to accommodate for this.

co-authored-by: IsabelleHjelden